### PR TITLE
Add admin list filter for command status

### DIFF
--- a/command_log/admin.py
+++ b/command_log/admin.py
@@ -4,6 +4,8 @@ import ast
 import json
 
 from django.contrib import admin
+from django.db import models
+from django.http import HttpRequest
 from django.utils.safestring import mark_safe
 
 from command_log.models import ManagementCommandLog
@@ -18,9 +20,41 @@ def pretty_print(data: dict | None) -> str:
     return mark_safe("<pre><code>%s</code></pre>" % html)  # noqa: S308, S703
 
 
+class StatusListFilter(admin.SimpleListFilter):
+    title = "status"
+    parameter_name = "status"
+
+    def lookups(
+        self,
+        request: HttpRequest,
+        model_admin: ManagementCommandLogAdmin,
+    ) -> tuple[tuple[str, str], ...]:
+        return (
+            ("0", "In progress"),
+            ("1", "Complete"),
+        )
+
+    def queryset(
+        self,
+        request: HttpRequest,
+        queryset: models.QuerySet[ManagementCommandLog],
+    ) -> models.QuerySet[ManagementCommandLog]:
+        if self.value() == "0":
+            return queryset.filter(started_at__isnull=False, finished_at__isnull=True)
+        if self.value() == "1":
+            return queryset.filter(started_at__isnull=False, finished_at__isnull=False)
+        return queryset
+
+
 class ManagementCommandLogAdmin(admin.ModelAdmin):
     list_display = ("management_command", "started_at", "duration", "exit_code_display")
-    list_filter = ("started_at", "app_name", "command_name", "exit_code")
+    list_filter = (
+        "started_at",
+        "app_name",
+        "command_name",
+        "exit_code",
+        StatusListFilter,
+    )
     search_fields = ("command_name",)
     readonly_fields = (
         "management_command",

--- a/command_log/admin.py
+++ b/command_log/admin.py
@@ -50,10 +50,10 @@ class ManagementCommandLogAdmin(admin.ModelAdmin):
     list_display = ("management_command", "started_at", "duration", "exit_code_display")
     list_filter = (
         "started_at",
+        StatusListFilter,
+        "exit_code",
         "app_name",
         "command_name",
-        "exit_code",
-        StatusListFilter,
     )
     search_fields = ("command_name",)
     readonly_fields = (


### PR DESCRIPTION
Adds a new admin list filter to enable filtering of "in progress" commands - defined as those with a start timestamp but not finish timestamp.

<img width="264" alt="Screenshot 2024-03-06 at 15 29 35" src="https://github.com/yunojuno/django-management-command-log/assets/200944/f4803ef5-0ad8-4925-85b6-2e47c7abbe10">


@tim-mccurrach - any use?